### PR TITLE
[20901] Documentation: Installation manual - Include Qt flag in docker compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     environment:
       - node=orchestrator
       - DISPLAY=${DISPLAY}
+      - QT_QUICK_BACKEND=software
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
     network_mode: host


### PR DESCRIPTION
This PR includes a macOS necessary flag in the docker compose GUI container.
Related PR:
- eProsima/SustainML-Library#41