### PR TITLE
[22027] Remove Orchestrator from Front-end framework app

### DIFF
--- a/SustainML.pro
+++ b/SustainML.pro
@@ -1,4 +1,4 @@
-QT += quick
+QT += quick network
 
 # You can make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.

--- a/include/sustainml/Engine.h
+++ b/include/sustainml/Engine.h
@@ -32,7 +32,6 @@
 #include <QWaitCondition>
 
 #include <sustainml_cpp/core/Constants.hpp>
-#include <sustainml_cpp/orchestrator/OrchestratorNode.hpp>
 #include <sustainml_cpp/types/types.hpp>
 
 class Engine : public QQmlApplicationEngine
@@ -139,10 +138,6 @@ private:
     sustainml::NodeID get_node_from_json(
             const QJsonObject& json);
 
-    QString get_task_from_data(
-            const sustainml::NodeID& id,
-            void* data);
-
     QString get_task_from_json(
             const QJsonObject& json);
 
@@ -153,20 +148,11 @@ private:
             const types::TaskId& task_id);
 
     QString get_raw_output(
-            const sustainml::NodeID& id,
-            void* data);
-
-    QString get_raw_output_json(
             const QJsonObject& json);
 
     QString update_node_status(
             const sustainml::NodeID& id,
             const types::NodeStatus& status);
-
-    size_t split_string(
-            const std::string& string,
-            std::vector<std::string>& string_set,
-            char delimeter);
 
     size_t split_string(
             const std::string& string,

--- a/include/sustainml/Engine.h
+++ b/include/sustainml/Engine.h
@@ -142,7 +142,9 @@ protected:
 
 private slots:
 
-    void replyFinished(QNetworkReply *reply);
+    void user_input_response(QNetworkReply *reply);
+
+    void node_response(QNetworkReply* reply);
 
 private:
 
@@ -179,7 +181,8 @@ private:
             QJsonArray& string_array,
             char delimeter);
 
-    QNetworkAccessManager* network_manager_;
+    QNetworkAccessManager* user_input_request_;
+    std::array<QNetworkAccessManager*, static_cast<size_t>(sustainml::NodeID::MAX)> node_responses_;
     sustainml::orchestrator::OrchestratorNode* orchestrator;
 };
 

--- a/include/sustainml/Engine.h
+++ b/include/sustainml/Engine.h
@@ -35,9 +35,7 @@
 #include <sustainml_cpp/orchestrator/OrchestratorNode.hpp>
 #include <sustainml_cpp/types/types.hpp>
 
-class Engine : public QQmlApplicationEngine,
-    public sustainml::orchestrator::OrchestratorNodeHandle,
-    public std::enable_shared_from_this<Engine>
+class Engine : public QQmlApplicationEngine
 {
     Q_OBJECT
 
@@ -55,25 +53,6 @@ public:
      * @return Engine pointer
      */
     QObject* enable();
-
-    /**
-     * @brief New node output callback
-     * @param   id node identifier
-     * @param data data received
-     */
-    void on_new_node_output(
-            const sustainml::NodeID& id,
-            void* data) override;
-
-    /**
-     * @brief Node status change callback
-     *
-     * @param id node identifier
-     * @param status new status
-     */
-    void on_node_status_change(
-            const sustainml::NodeID& id,
-            const types::NodeStatus& status) override;
 
 public slots:
 
@@ -196,7 +175,6 @@ private:
 
     QNetworkAccessManager* user_input_request_;
     std::array<QNetworkAccessManager*, static_cast<size_t>(sustainml::NodeID::MAX)> node_responses_;
-    sustainml::orchestrator::OrchestratorNode* orchestrator;
 };
 
 #endif //_EPROSIMA_SUSTAINML_ENGINE_H

--- a/include/sustainml/Engine.h
+++ b/include/sustainml/Engine.h
@@ -24,14 +24,16 @@
 
 #include <memory>
 
+#include <QNetworkAccessManager>
 #include <QQmlApplicationEngine>
 #include <QQueue>
 #include <QtCharts/QVXYModelMapper>
 #include <QThread>
 #include <QWaitCondition>
 
+#include <sustainml_cpp/core/Constants.hpp>
 #include <sustainml_cpp/orchestrator/OrchestratorNode.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 class Engine : public QQmlApplicationEngine,
     public sustainml::orchestrator::OrchestratorNodeHandle,
@@ -72,6 +74,7 @@ public:
     void on_node_status_change(
             const sustainml::NodeID& id,
             const types::NodeStatus& status) override;
+
 
 public slots:
 
@@ -137,7 +140,13 @@ protected:
     //! Set to true if the engine is being enabled
     bool enabled_;
 
+private slots:
+
+    void replyFinished(QNetworkReply *reply);
+
 private:
+
+    const QString server_url_ = "http://127.0.0.1:5001";
 
     QString get_name_from_node_id(
             const sustainml::NodeID& id);
@@ -165,7 +174,12 @@ private:
             std::vector<std::string>& string_set,
             char delimeter);
 
+    size_t split_string(
+            const std::string& string,
+            QJsonArray& string_array,
+            char delimeter);
 
+    QNetworkAccessManager* network_manager_;
     sustainml::orchestrator::OrchestratorNode* orchestrator;
 };
 

--- a/include/sustainml/Engine.h
+++ b/include/sustainml/Engine.h
@@ -75,7 +75,6 @@ public:
             const sustainml::NodeID& id,
             const types::NodeStatus& status) override;
 
-
 public slots:
 
     /**
@@ -142,9 +141,11 @@ protected:
 
 private slots:
 
-    void user_input_response(QNetworkReply *reply);
+    void user_input_response(
+            QNetworkReply* reply);
 
-    void node_response(QNetworkReply* reply);
+    void node_response(
+            QNetworkReply* reply);
 
 private:
 
@@ -153,9 +154,18 @@ private:
     QString get_name_from_node_id(
             const sustainml::NodeID& id);
 
+    sustainml::NodeID get_node_id_from_name(
+            const QString& name);
+
+    sustainml::NodeID get_node_from_json(
+            const QJsonObject& json);
+
     QString get_task_from_data(
             const sustainml::NodeID& id,
             void* data);
+
+    QString get_task_from_json(
+            const QJsonObject& json);
 
     QString get_status_from_node(
             const types::NodeStatus& status);
@@ -166,6 +176,9 @@ private:
     QString get_raw_output(
             const sustainml::NodeID& id,
             void* data);
+
+    QString get_raw_output_json(
+            const QJsonObject& json);
 
     QString update_node_status(
             const sustainml::NodeID& id,

--- a/src/cpp/Engine.cpp
+++ b/src/cpp/Engine.cpp
@@ -48,9 +48,6 @@ QObject* Engine::enable()
     // Load main GUI
     load(QUrl(QLatin1String("qrc:/qml/main.qml")));
 
-    // Initialize orchestrator node
-    orchestrator = new sustainml::orchestrator::OrchestratorNode(*this);
-
     // Initialize user input request manager
     user_input_request_ = new QNetworkAccessManager(this);
     connect(user_input_request_, SIGNAL(finished(QNetworkReply*)), this, SLOT(user_input_response(QNetworkReply*)));
@@ -70,33 +67,6 @@ QObject* Engine::enable()
 
 Engine::~Engine()
 {
-    if  (enabled_)
-    {
-        delete orchestrator;
-    }
-}
-
-void Engine::on_new_node_output(
-        const sustainml::NodeID& id,
-        void* data)
-{
-    //emit update_log(QString("Output received. Task ") + get_task_from_data(id, data) + (",\tnode ") +
-    //        get_name_from_node_id(id) + ":\n" + get_raw_output(id, data));
-}
-
-void Engine::on_node_status_change(
-        const sustainml::NodeID& id,
-        const types::NodeStatus& status)
-{
-    if (PRINT_STATUS_LOG)
-    {
-        emit update_log(get_name_from_node_id(id) + QString(" node status changed to ") +
-                update_node_status(id, status));
-    }
-    else
-    {
-        update_node_status(id, status);
-    }
 }
 
 void Engine::launch_task(

--- a/src/cpp/Engine.cpp
+++ b/src/cpp/Engine.cpp
@@ -66,6 +66,11 @@ QObject* Engine::enable()
 
 Engine::~Engine()
 {
+    delete user_input_request_;
+    for (size_t i = 0; i < static_cast<size_t>(sustainml::NodeID::MAX); ++i)
+    {
+        delete node_responses_[i];
+    }
 }
 
 void Engine::launch_task(

--- a/src/cpp/Engine.cpp
+++ b/src/cpp/Engine.cpp
@@ -30,7 +30,6 @@
 
 #include <sustainml/Engine.h>
 
-#include <sustainml_cpp/orchestrator/OrchestratorNode.hpp>
 #include <sustainml_cpp/types/types.hpp>
 
 #define PRINT_STATUS_LOG false
@@ -250,46 +249,6 @@ sustainml::NodeID Engine::get_node_from_json(
     }
 }
 
-QString Engine::get_task_from_data(
-        const sustainml::NodeID& id,
-        void* data)
-{
-    types::AppRequirements* requirements = nullptr;
-    types::CO2Footprint* carbon = nullptr;
-    types::HWConstraints* hw_constraints = nullptr;
-    types::HWResource* hw_resources = nullptr;
-    types::MLModel* model = nullptr;
-    types::MLModelMetadata* metadata = nullptr;
-    types::UserInput* input = nullptr;
-
-    switch (id)
-    {
-        case sustainml::NodeID::ID_APP_REQUIREMENTS:
-            requirements = static_cast<types::AppRequirements*>(data);
-            return get_task_QString(requirements->task_id());
-        case sustainml::NodeID::ID_CARBON_FOOTPRINT:
-            carbon = static_cast<types::CO2Footprint*>(data);
-            return get_task_QString(carbon->task_id());
-        case sustainml::NodeID::ID_HW_CONSTRAINTS:
-            hw_constraints = static_cast<types::HWConstraints*>(data);
-            return get_task_QString(hw_constraints->task_id());
-        case sustainml::NodeID::ID_HW_RESOURCES:
-            hw_resources = static_cast<types::HWResource*>(data);
-            return get_task_QString(hw_resources->task_id());
-        case sustainml::NodeID::ID_ML_MODEL:
-            model = static_cast<types::MLModel*>(data);
-            return get_task_QString(model->task_id());
-        case sustainml::NodeID::ID_ML_MODEL_METADATA:
-            metadata = static_cast<types::MLModelMetadata*>(data);
-            return get_task_QString(metadata->task_id());
-        case sustainml::NodeID::ID_ORCHESTRATOR:
-            input = static_cast<types::UserInput*>(data);
-            return get_task_QString(input->task_id());
-        default:
-            return QString("UNKNOWN");
-    }
-}
-
 QString Engine::get_task_from_json(
         const QJsonObject& json)
 {
@@ -334,123 +293,6 @@ QString Engine::get_task_QString(
 }
 
 QString Engine::get_raw_output(
-        const sustainml::NodeID& id,
-        void* data)
-{
-    QString output = "";
-    types::AppRequirements* requirements = nullptr;
-    types::CO2Footprint* carbon = nullptr;
-    types::HWConstraints* hw_constraints = nullptr;
-    types::HWResource* hw_resources = nullptr;
-    types::MLModel* model = nullptr;
-    types::MLModelMetadata* metadata = nullptr;
-    types::UserInput* input = nullptr;
-
-    switch (id)
-    {
-        case sustainml::NodeID::ID_APP_REQUIREMENTS:
-            requirements = static_cast<types::AppRequirements*>(data);
-            output += "App requirements: ";
-            for (std::string req : requirements->app_requirements())
-            {
-                output += QString::fromStdString(req) + QString(", ");
-            }
-            output += "\n";
-            return output;
-        case sustainml::NodeID::ID_CARBON_FOOTPRINT:
-            carbon = static_cast<types::CO2Footprint*>(data);
-            output += QString("Carbon footprint: ") + QString::number(carbon->carbon_footprint()) + QString("\n");
-            output += QString("Energy consumption: ") + QString::number(carbon->energy_consumption()) + QString("\n");
-            output += QString("Carbon intensity: ") + QString::number(carbon->carbon_intensity()) + QString("\n");
-            return output;
-        case sustainml::NodeID::ID_HW_CONSTRAINTS:
-            hw_constraints = static_cast<types::HWConstraints*>(data);
-            output += QString("Max memory footprint: ") + QString::number(hw_constraints->max_memory_footprint()) +
-                    QString("\n");
-            output += "Hardware required: ";
-            for (std::string hw_req : hw_constraints->hardware_required())
-            {
-                output += QString::fromStdString(hw_req) + QString(", ");
-            }
-            output += QString("\n");
-            return output;
-        case sustainml::NodeID::ID_HW_RESOURCES:
-            hw_resources = static_cast<types::HWResource*>(data);
-            output += QString("Hardware description: ") +
-                    QString::fromStdString(hw_resources->hw_description()) + QString("\n");
-            output += QString("Power consumption: ") +
-                    QString::number(hw_resources->power_consumption()) + QString("\n");
-            output += QString("Latency: ") + QString::number(hw_resources->latency()) + QString("\n");
-            output += QString("Model memory footprint: ") +
-                    QString::number(hw_resources->memory_footprint_of_ml_model()) + QString("\n");
-            output += QString("Max hardware memory footprint: ") +
-                    QString::number(hw_resources->max_hw_memory_footprint()) + QString("\n");
-            return output;
-        case sustainml::NodeID::ID_ML_MODEL:
-            model = static_cast<types::MLModel*>(data);
-            output += QString("Model path: ") + QString::fromStdString(model->model_path()) + QString("\n");
-            output += QString("Model: ") + QString::fromStdString(model->model()) + QString("\n");
-            output += QString("Model properties path: ") +
-                    QString::fromStdString(model->model_properties_path()) + QString("\n");
-            output += QString("Model properties: ") + QString::fromStdString(model->model_properties()) + QString("\n");
-            output += "Input batch: ";
-            for (std::string input : model->input_batch())
-            {
-                output += QString::fromStdString(input) + QString(", ");
-            }
-            output += QString("\nTarget latency: ") + QString::number(model->target_latency()) + QString("\n");
-            return output;
-        case sustainml::NodeID::ID_ML_MODEL_METADATA:
-            metadata = static_cast<types::MLModelMetadata*>(data);
-            output += "Key words: ";
-            for (std::string keyword : metadata->keywords())
-            {
-                output += QString::fromStdString(keyword) + QString(", ");
-            }
-            output += "\nMetadata: ";
-            for (std::string meta : metadata->ml_model_metadata())
-            {
-                output += QString::fromStdString(meta) + QString(", ");
-            }
-            output += "\n";
-            return output;
-        case sustainml::NodeID::ID_ORCHESTRATOR:
-            input = static_cast<types::UserInput*>(data);
-            output += QString("Problem short description: ") +
-                    QString::fromStdString(input->problem_short_description()) + QString("\n");
-            output += QString("Problem definition: ") +
-                    QString::fromStdString(input->problem_definition()) + QString("\n");
-            output += QString("Modality: ") + QString::fromStdString(input->modality()) + QString("\n");
-            output += QString("Inputs: ");
-            for (std::string in : input->inputs())
-            {
-                output += QString::fromStdString(in) + QString(", ");
-            }
-            output += "\nOutputs: ";
-            for (std::string out : input->outputs())
-            {
-                output += QString::fromStdString(out) + QString(", ");
-            }
-            output += QString("\nMin samples: ") + QString::number(input->minimum_samples()) + QString("\n");
-            output += QString("Max samples: ") + QString::number(input->maximum_samples()) + QString("\n");
-            output += QString("Optimize automatically: ") +
-                    (input->optimize_carbon_footprint_auto() ? QString("true\n") : QString("false\n"));
-            output += QString("Optimize manually: ") +
-                    (input->optimize_carbon_footprint_manual() ? QString("true\n") : QString("false\n"));
-            output += QString("Previous iteration: ") + QString::number(input->previous_iteration()) + QString("\n");
-            output += QString("Desired carbon footprint: ") +
-                    QString::number(input->desired_carbon_footprint()) + QString("\n");
-            output += QString("Geo location continent: ") +
-                    QString::fromStdString(input->geo_location_continent()) + QString("\n");
-            output += QString("Geo location region: ") +
-                    QString::fromStdString(input->geo_location_region()) + QString("\n");
-            return output;
-        default:
-            return QString("Unknown node output\n");
-    }
-}
-
-QString Engine::get_raw_output_json(
         const QJsonObject& json_obj)
 {
     QString output = "";
@@ -555,27 +397,6 @@ QString Engine::update_node_status(
 
 size_t Engine::split_string(
         const std::string& string,
-        std::vector<std::string>& string_set,
-        char delimeter)
-{
-    size_t position = string.find(delimeter);
-    size_t initial_position = 0;
-    string_set.clear();
-
-    // Split loop
-    while (position != std::string::npos)
-    {
-        string_set.push_back(string.substr(initial_position, position - initial_position));
-        initial_position = position + 1;
-        position = string.find(delimeter, initial_position);
-    }
-    string_set.push_back(string.substr(initial_position, std::min(position, string.size()) - initial_position + 1));
-
-    return string_set.size();
-}
-
-size_t Engine::split_string(
-        const std::string& string,
         QJsonArray& string_array,
         char delimeter)
 {
@@ -616,9 +437,8 @@ void Engine::node_response(
     if (!json_obj.empty())
     {
         QString name = get_name_from_node_id(get_node_from_json(json_obj));
-        emit update_log(QString("Output received. Task ") + get_task_from_json(json_obj[name].toObject()) +
-                (",\tnode ") +
-                name + ":\n" + get_raw_output_json(json_obj));
+        emit update_log(QString("Output received. ") + get_task_from_json(json_obj[name].toObject()) +
+                (",\tnode ") + name + ":\n" + get_raw_output(json_obj));
     }
     reply_->deleteLater();
 }


### PR DESCRIPTION
This PR removes the orchestrator usage from the front-end framework app, as it is deployed separately in another python node.
It performs all communication pipeline through API REST.

This PR is on top of (and must be merged after):
- #15 

Related PRs:
- https://github.com/eProsima/SustainML-Library/pull/58
