### PR TITLE
[22460] Bugfix: `run.bash` absolute desktop container path and install correct package in Dockerfile 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update && apt install --yes --no-install-recommends \
         wget git cmake g++ build-essential python3 python3.10-venv python3-pip libpython3-dev swig \
         libssl-dev libasio-dev libtinyxml2-dev libp11-dev libengine-pkcs11-openssl softhsm2 \
         qtdeclarative5-dev libqt5charts5-dev qtquickcontrols2-5-dev libqt5svg5 qml-module-qtquick-controls \
-        qml-module-qtquick-controls2 && \
+        qml-module-qtquick-controls2 qml-module-qt-labs-qmlmodels && \
     pip3 install -U \
         colcon-common-extensions vcstool
 

--- a/docker/run.bash
+++ b/docker/run.bash
@@ -3,7 +3,7 @@
 source "/sustainml/install/setup.bash"
 
 if [[ ${node} == "desktop" ]]; then
-    ./sustainml/build/sustainml/sustainml
+    /sustainml/build/sustainml/sustainml
 else
     cd /sustainml/src/sustainml_lib/sustainml_modules/sustainml_modules/
     if [[ ${node} == "back-end" ]]; then


### PR DESCRIPTION
This PR corrects `run.bash` absolute desktop container path and install correct package in Dockerfile 