### PR TITLE
[23081] Fix Docker build error due to sustainml.repos versions

### DIFF
--- a/sustainml.repos
+++ b/sustainml.repos
@@ -18,8 +18,8 @@ repositories:
     sustainml_lib:
         type: git
         url: https://github.com/eProsima/SustainML-Library.git
-        version: feature/domain_env
+        version: main
     sustainml_framework:
         type: git
         url: https://github.com/eProsima/SustainML-Framework.git
-        version: feature/update_docker
+        version: main


### PR DESCRIPTION
This PR change the versions of `Sustainml-Library` and `Sustainml-Framework` to `main`.