### PR TITLE
[23178] Delate transaction_id and node_id from frontend

### DIFF
--- a/src/cpp/Engine.cpp
+++ b/src/cpp/Engine.cpp
@@ -206,9 +206,8 @@ void Engine::request_status()
 void Engine::request_modalities()
 {
     QJsonObject json_config;
-    json_config["node_id"] = 4;
-    json_config["transaction_id"] = 0;
     json_config["configuration"] = "modality";
+    json_config["node_id"] = 4;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {
@@ -234,9 +233,8 @@ void Engine::request_modalities()
 void Engine::request_inout_modalities()
 {
     QJsonObject json_config;
-    json_config["node_id"] = 4;
-    json_config["transaction_id"] = 0;
     json_config["configuration"] = "in_out_modalities";
+    json_config["node_id"] = 4;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {
@@ -262,9 +260,8 @@ void Engine::request_inout_modalities()
 void Engine::request_goals()
 {
     QJsonObject json_config;
-    json_config["node_id"] = 5;
-    json_config["transaction_id"] = 0;
     json_config["configuration"] = "goal";
+    json_config["node_id"] = 5;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {
@@ -289,9 +286,8 @@ void Engine::request_goals()
 void Engine::request_hardwares()
 {
     QJsonObject json_config;
-    json_config["node_id"] = 3;
-    json_config["transaction_id"] = 1;
     json_config["configuration"] = "hardwares";
+    json_config["node_id"] = 3;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {
@@ -318,9 +314,8 @@ void Engine::request_metrics(
     QString req_type_values)
 {
     QJsonObject json_config;
-    json_config["node_id"] = 4;
-    json_config["transaction_id"] = 2;
     json_config["configuration"] = "metrics, " + metric_req_type + ": " + req_type_values;
+    json_config["node_id"] = 4;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {
@@ -346,9 +341,8 @@ void Engine::request_model_info(
     QString mode_name)
 {
     QJsonObject json_config;
-    json_config["node_id"] = 4;
-    json_config["transaction_id"] = 1;
     json_config["configuration"] = "model_info, " + mode_name;
+    json_config["node_id"] = 4;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {
@@ -382,9 +376,8 @@ void Engine::request_problem_from_modality(
     QString modality)
 {
     QJsonObject json_config;
-    json_config["node_id"] = 4;
-    json_config["transaction_id"] = 3;
     json_config["configuration"] = "problem_from_modality, " + modality;
+    json_config["node_id"] = 4;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {
@@ -410,9 +403,8 @@ void Engine::request_model_from_goal(
     QString goal)
 {
     QJsonObject json_config;
-    json_config["node_id"] = 5;
-    json_config["transaction_id"] = 1;
     json_config["configuration"] = "model_from_goal, " + goal;
+    json_config["node_id"] = 5;
 
     config_request(json_config, [this](const QJsonObject& json_obj)
             {

--- a/src/qml/screens/SmlProblemDefinitionScreen.qml
+++ b/src/qml/screens/SmlProblemDefinitionScreen.qml
@@ -123,7 +123,7 @@ Item
             root.__max_memory_footprint = max_memory_footprint
             root.__previous_iteration = iteration_id
             root.__previous_problem_id = problem_id
-            root.__num_outputs = num_outputs
+            root.__num_outputs = 1
         }
     }
 
@@ -883,7 +883,6 @@ Item
         SmlInput
         {
             id: num_outputs_input
-            disabled: root.__reiterate
             text: root.__num_outputs === 0 ? "" : root.__num_outputs
             placeholder_text: text !== "" ? "" : "Set quantity of output models (only numbers)"
             border_color: Settings.app_color_green_3


### PR DESCRIPTION
This PR delate node_id and transaction_id from frontend. This information is transparent to the frontend, the backend is the one setting them.
Also, not disable num_output on reiteration.

Depend on 
* https://github.com/eProsima/SustainML-Library/pull/74