### PR TITLE
Add the executable `sustainml-framework` to easier use of `framework_run.sh`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,3 +153,10 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 # Packaging
 ###############################################################################
 eprosima_packaging()
+
+###############################################################################
+# Framework Install targets
+###############################################################################
+install(PROGRAMS framework_run.sh
+        DESTINATION bin
+        RENAME sustainml-framework)


### PR DESCRIPTION
This PR add the installation of an executable on terminal from `framework_run.sh` to be able to use it easier, and not having to run the file itself.