### PR TITLE
[23297] Add back Carbon Footprint to result screens

### DIFF
--- a/src/qml/fragments/SmlComparisonFragment.qml
+++ b/src/qml/fragments/SmlComparisonFragment.qml
@@ -98,7 +98,7 @@ Rectangle
                         case "Power Consumption [W]":
                             valuesArray.push(data.HW_RESOURCES.power_consumption);
                             break;
-                        case "Carbon Footprint [kgCO2e]":
+                        case "Carbon Footprint [gCO2e]":
                             valuesArray.push(data.CARBON_FOOTPRINT.carbon_footprint);
                             break;
                         case "Carbon Intensity [gCO2/kW]":

--- a/src/qml/fragments/SmlGeneralFragment.qml
+++ b/src/qml/fragments/SmlGeneralFragment.qml
@@ -26,7 +26,7 @@ Rectangle
     // signal go_reiterate();
 
     // Private properties
-    property var minColumnWidths: [45, 45, 100, 160, 180, 160, 170, 185]
+    property var minColumnWidths: [45, 45, 100, 160, 180, 160, 170, 170, 185]
     property int sumMinColumnWidths: {
         var total = 0;
         for (var i = 0; i < minColumnWidths.length; i++) {
@@ -34,7 +34,7 @@ Rectangle
         }
         return total;
     }
-    property var columnWidths: [45, 45, 100, 160, 180, 160, 170, 185]
+    property var columnWidths: [45, 45, 100, 160, 180, 160, 170, 170, 185]
     readonly property int __margin: Settings.spacing_big * 2
     readonly property int __scroll_view_height: height
     readonly property int __scroll_view_content_height: 700
@@ -50,7 +50,8 @@ Rectangle
     readonly property int __suggested_model_column: 4
     readonly property int __hw_description_column: 5
     readonly property int __power_consumption_column: 6
-    readonly property int __carbon_intensity_column: 7
+    readonly property int __carbon_footprint_column: 7
+    readonly property int __carbon_intensity_column: 8
 
     property string errorMessage: ""
 
@@ -65,6 +66,7 @@ Rectangle
         TableModelColumn {display: "Suggested model"}
         TableModelColumn {display: "Suggested hardware"}
         TableModelColumn {display: "Power consumption"}
+        TableModelColumn {display: "Carbon footprint"}
         TableModelColumn {display: "Carbon intensity"}
 
         rows: []
@@ -109,6 +111,7 @@ Rectangle
                             "Suggested model" : "",
                             "Suggested hardware" : "",
                             "Power consumption" : "",
+                            "Carbon footprint" : "",
                             "Carbon intensity" : ""
                         }
                     )
@@ -143,6 +146,7 @@ Rectangle
                             "Suggested model" : model,
                             "Suggested hardware" : "",
                             "Power consumption" : "",
+                            "Carbon footprint" : "",
                             "Carbon intensity" : ""
                         }
                     )
@@ -178,6 +182,7 @@ Rectangle
                             "Suggested model" : "",
                             "Suggested hardware" : hw_description,
                             "Power consumption" : power_consumption,
+                            "Carbon footprint" : "",
                             "Carbon intensity" : ""
                         }
                     )
@@ -198,7 +203,7 @@ Rectangle
                 var row = table_model.contains(iteration_id)
                 if(row >= 0)
                 {
-                    // table_model.setData(table_model.index(row, __carbon_footprint_column), "display", carbon_footprint)
+                    table_model.setData(table_model.index(row, __carbon_footprint_column), "display", carbon_footprint)
                     table_model.setData(table_model.index(row, __carbon_intensity_column), "display", carbon_intensity)
                     general_table.height = __data_height * table_model.rows.length;
                 }
@@ -213,6 +218,7 @@ Rectangle
                             "Suggested model" : "",
                             "Suggested hardware" : "",
                             "Power consumption" : "",
+                            "Carbon footprint" : carbon_footprint,
                             "Carbon intensity" : carbon_intensity
                         }
                     )
@@ -319,6 +325,7 @@ Rectangle
                         TableModelColumn {display: "Suggested model"}
                         TableModelColumn {display: "Suggested hardware"}
                         TableModelColumn {display: "Power consumption"}
+                        TableModelColumn {display: "Carbon footprint"}
                         TableModelColumn {display: "Carbon intensity"}
 
                         rows: [
@@ -329,6 +336,7 @@ Rectangle
                             "Suggested model" : "ML Model",
                             "Suggested hardware" : "Hardware",
                             "Power consumption" : "Power Consumption [W]",
+                            "Carbon footprint" : "Carbon Footprint [gCO2e]",
                             "Carbon intensity" : "Carbon Intensity [gCO2/kW]"}
                         ]
                     }

--- a/src/qml/fragments/SmlIterationFragment.qml
+++ b/src/qml/fragments/SmlIterationFragment.qml
@@ -23,8 +23,8 @@ Rectangle {
     signal component_signal(string viewType, string signal_kind, string id)
 
     // Property to decide the visibles columns
-    property var visibleColumns: [0,1,2,3,4,5,6,7]
-    property var minColumnWidths: [80, 160, 180, 150, 140, 160, 170, 185]
+    property var visibleColumns: [0,1,2,3,4,5,6,7,8]
+    property var minColumnWidths: [80, 160, 180, 150, 140, 160, 170, 170, 185]
     property int sumMinColumnWidths: {
         var total = 0;
         for (var i = 0; i < minColumnWidths.length; i++) {
@@ -32,7 +32,7 @@ Rectangle {
         }
         return total;
     }
-    property var columnWidths: [80, 160, 180, 150, 140, 160, 170, 185]
+    property var columnWidths: [80, 160, 180, 150, 140, 160, 170, 170, 185]
     property var jsonList : []
     readonly property int fixedColumnWidth: 150
     readonly property int __margin: Settings.spacing_big * 2
@@ -52,6 +52,7 @@ Rectangle {
         TableModelColumn { display: "Suggested hardware" }
         TableModelColumn { display: "Latency" }
         TableModelColumn { display: "Power consumption" }
+        TableModelColumn { display: "Carbon footprint"}
         TableModelColumn { display: "Carbon intensity" }
         TableModelColumn { display: "Energy Consumption" }
 
@@ -86,6 +87,7 @@ Rectangle {
                     "Suggested hardware": json.HW_RESOURCES.hw_description,
                     "Latency": formatNumber(json.HW_RESOURCES.latency),
                     "Power consumption": formatNumber(json.HW_RESOURCES.power_consumption),
+                    "Carbon footprint": formatNumber(json.CARBON_FOOTPRINT.carbon_footprint),
                     "Carbon intensity": formatNumber(json.CARBON_FOOTPRINT.carbon_intensity),
                     "Energy Consumption": formatNumber(json.CARBON_FOOTPRINT.energy_consumption)
                 });
@@ -190,6 +192,7 @@ Rectangle {
                         TableModelColumn { display: "Suggested hardware" }
                         TableModelColumn { display: "Latency" }
                         TableModelColumn { display: "Power consumption" }
+                        TableModelColumn { display: "Carbon footprint" }
                         TableModelColumn { display: "Carbon intensity" }
                         TableModelColumn { display: "Energy Consumption" }
 
@@ -200,6 +203,7 @@ Rectangle {
                             "Suggested hardware" : "Hardware",
                             "Latency" : "Latency [ms]",
                             "Power consumption" : "Power Consumption [W]",
+                            "Carbon footprint" : "Carbon Footprint [gCO2e]",
                             "Carbon intensity" : "Carbon Intensity [gCO2/kW]",
                             "Energy Consumption" : "Energy Consumption [kWh]"}
                         ]
@@ -568,7 +572,7 @@ Rectangle {
                 }
 
                 Repeater {
-                    model: [1,2,3,4,5,6,7]
+                    model: [1,2,3,4,5,6,7,8]
                     delegate: Row {
                         spacing: 5
                         CheckBox {
@@ -590,7 +594,7 @@ Rectangle {
                         Text {
                             anchors.verticalCenter: parent.verticalCenter
                             text: {
-                                var headers = ["Problem", "ML Model", "Hardware", "Latency", "Power Consumption", "Carbon Intensity", "Energy Consumption"];
+                                var headers = ["Problem", "ML Model", "Hardware", "Latency", "Power Consumption", "Carbon Footprint", "Carbon Intensity", "Energy Consumption"];
                                 return headers[modelData - 1];
                             }
                         }


### PR DESCRIPTION
This PR add back Carbon Footprint [gCO2] results data to the results screens after the data has been fix and made it real with the use of the model loaded.


Depends on https://github.com/eProsima/SustainML-Library/pull/79.

Goes after #34.