### PR TITLE
[23586] Save and load tasks results with SQL database

### DIFF
--- a/include/sustainml/Engine.hpp
+++ b/include/sustainml/Engine.hpp
@@ -213,6 +213,14 @@ public slots:
         int iteration_id,
         bool reiteration = false);
 
+    /**
+     * @brief private method to request previous task information.
+     *
+     * @param tasks list of tasks to add
+     */
+    void add_known_tasks(
+        const QVariantList& tasks);
+
 signals:
 
     /**
@@ -470,6 +478,7 @@ signals:
      */
     void dataset_metadata_available(
         const QVariantMap& dataset_metadata);
+
     /**
      * @brief Goals received signal to display in the GUI
      *
@@ -600,6 +609,14 @@ private:
     void config_response(
             const REST_requester* requester,
             const QJsonObject& json_obj);
+
+    //! Request all tasks available on the backend
+    void available_tasks_request();
+
+    //! Receive and propagate the available tasks
+    void available_tasks_response(
+        const REST_requester* requester,
+        const QJsonObject& json_obj);
 
     QTimer* node_status_timer_;
 

--- a/include/sustainml/REST_requester.hpp
+++ b/include/sustainml/REST_requester.hpp
@@ -48,7 +48,8 @@ public:
         SEND_USER_INPUT,
         REQUEST_RESULTS,
         REQUEST_NODE_STATUS,
-        REQUEST_CONFIG
+        REQUEST_CONFIG,
+        REQUEST_AVAILABLE_TASKS
     };
 
     //! Object performs a REST request and registers the functor for the response management

--- a/src/cpp/Engine.cpp
+++ b/src/cpp/Engine.cpp
@@ -59,6 +59,8 @@ QObject* Engine::enable()
     // Start timer
     node_status_timer_->start();
 
+    available_tasks_request();
+
     return rootObjects().value(0);
 }
 
@@ -208,7 +210,7 @@ void Engine::launch_dataset_path_task(
                 QJsonObject config_obj = config_doc.object();
 
                 emit dataset_metadata_available(config_obj.toVariantMap());
-                
+
             }
         }
     });
@@ -622,6 +624,23 @@ void Engine::request_orchestrator(
     orchestrator_request(node_json_data);
 }
 
+void Engine::add_known_tasks(const QVariantList& tasks)
+{
+    for (const QVariant& v : tasks)
+    {
+        const QVariantMap m = v.toMap();
+        const int p = m.value("problem_id").toInt();
+        const int it = m.value("iteration_id").toInt();
+        types::TaskId tid(p, it);
+
+        auto dup = std::find(received_task_ids.begin(), received_task_ids.end(), tid);
+        if (dup == received_task_ids.end())
+        {
+            received_task_ids.push_back(tid);
+        }
+    }
+}
+
 void Engine::send_reiteration_inputs(
     const QJsonObject& json_obj)
 {
@@ -1013,6 +1032,82 @@ void Engine::config_response(
         }
     }
     // Remove REST requester from queue
+    std::lock_guard<std::mutex> lock(requesters_mutex_);
+    for (auto it = requesters_.begin(); it != requesters_.end(); ++it)
+    {
+        if (*it == requester)
+        {
+            auto ptr = *it;
+            requesters_.erase(it);
+            (ptr)->disconnect();
+            (ptr)->deleteLater();
+            break;
+        }
+    }
+}
+
+void Engine::available_tasks_request()
+{
+    REST_requester* requester = new REST_requester(
+        std::bind(&Engine::available_tasks_response, this, std::placeholders::_1, std::placeholders::_2),
+        REST_requester::RequestType::REQUEST_AVAILABLE_TASKS,
+        QJsonObject()
+    );
+
+    {
+        std::lock_guard<std::mutex> lock(requesters_mutex_);
+        requesters_.push_back(requester);
+    }
+}
+
+void Engine::available_tasks_response(
+    const REST_requester* requester,
+    const QJsonObject& json_obj)
+{
+    if (!json_obj.empty())
+    {
+        QVariantList tasks;
+        if (json_obj.contains("task_ids") && json_obj["task_ids"].isArray())
+        {
+            QJsonArray arr = json_obj["task_ids"].toArray();
+            for (const QJsonValue& v : arr)
+            {
+                int problem_id = -1;
+                int iteration_id = -1;
+
+                if (v.isObject())
+                {
+                    QJsonObject o = v.toObject();
+                    problem_id = o.value("problem_id").toInt(-1);
+                    iteration_id = o.value("iteration_id").toInt(-1);
+                }
+                else if (v.isArray())
+                {
+                    QJsonArray a = v.toArray();
+                    if (a.size() >= 2)
+                    {
+                        problem_id = a.at(0).toInt(-1);
+                        iteration_id = a.at(1).toInt(-1);
+                    }
+                }
+                if (problem_id >= 0 && iteration_id >= 0)
+                {
+                    QVariantMap m;
+                    m["problem_id"] = problem_id;
+                    m["iteration_id"] = iteration_id;
+                    tasks.push_back(m);
+                }
+            }
+        }
+
+        if (!tasks.isEmpty())
+        {
+            add_known_tasks(tasks);
+
+            request_current_data(true);
+        }
+    }
+
     std::lock_guard<std::mutex> lock(requesters_mutex_);
     for (auto it = requesters_.begin(); it != requesters_.end(); ++it)
     {

--- a/src/cpp/REST_requester.cpp
+++ b/src/cpp/REST_requester.cpp
@@ -79,6 +79,9 @@ QString REST_requester::request_type_to_url(
         case RequestType::REQUEST_CONFIG:
             url += "/config_request";
             break;
+        case RequestType::REQUEST_AVAILABLE_TASKS:
+            url += "/available_tasks";
+            break;
     }
     return url;
 }

--- a/src/qml/screens/SmlProblemDefinitionScreen.qml
+++ b/src/qml/screens/SmlProblemDefinitionScreen.qml
@@ -71,7 +71,7 @@ Item
     property string __dataset_metadata_keywords: __dataset_keywords
     property string __dataset_metadata_applications: __dataset_applications
 
-    property bool results_available: false
+    property bool results_available: true
 
     // External signals
     signal go_home();

--- a/src/qml/screens/SmlResultsScreen.qml
+++ b/src/qml/screens/SmlResultsScreen.qml
@@ -262,7 +262,7 @@ Item
         anchors {
             horizontalCenter: parent.horizontalCenter
             top: parent.top
-            topMargin: Settings.spacing_big*1.5
+            topMargin: Settings.spacing_big
         }
     }
 

--- a/src/tree/TreeModel.cpp
+++ b/src/tree/TreeModel.cpp
@@ -20,7 +20,7 @@
 #include <sustainml/tree/TreeItem.h>
 #include <sustainml/tree/TreeModel.h>
 
-#include <iostream> // debug
+#include <iostream>
 
 TreeModel::TreeModel(
         const json& data,
@@ -219,18 +219,6 @@ void TreeModel::updateFromJsonString(const QString& json_str)
     try
     {
         json parsed = json::parse(json_str.toStdString());
-        std::cout << "TreeModel::updateFromJsonString: parsing succeeded." << std::endl;    // debug
-        if (parsed.is_object() || parsed.is_array())
-        {
-            std::cout << "TreeModel::updateFromJsonString: container type = "
-                      << (parsed.is_object() ? "object" : "array")
-                      << ", size = " << parsed.size() << std::endl;
-        }
-        else
-        {
-            std::cout << "TreeModel::updateFromJsonString: primitive JSON value" << std::endl;
-        }
-        std::cout << "TreeModel::updateFromJsonString: content:\n" << parsed.dump(2) << std::endl;  // debug
         update(parsed);
     }
     catch (const std::exception& e)


### PR DESCRIPTION
This PR introduces a new connection with the backend to received all available task_id, after reading from the SQL file, to show them all on Results screen.
It's still on-going

Goes after https://github.com/eProsima/SustainML-Framework/pull/39
This PR depend on the mergying of https://github.com/eProsima/SustainML-Library/pull/86

This PR is not yet finish. Still need to be fully tested and add a button to delate all database information from the backend.